### PR TITLE
Add smaller estimates and break option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The application is designed to be deployed as:
 1. Open the application in your browser
 2. Create a new room or join an existing one by entering the room ID
 3. Share the room ID with your team members
-4. Select your story point estimate by clicking on a card
+4. Select your story point estimate by clicking on a card (options range from
+   0.5 to 8, with ☕ indicating a coffee break)
 5. When everyone has voted, click "Reveal Votes" to show all estimates
 6. Click "Reset Votes" to start a new round
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -23,7 +23,7 @@
   let joinRoomId = $state(initialRoomId || "");
 
   // Card values
-  const cardValues = ["1", "2", "3", "5", "8", "13", "21", "34", "?"];
+  const cardValues = ["0.5", "1", "2", "3", "5", "8", "\u2615", "?"];
 
   function connectSocket() {
     // Make sure to disconnect any existing connection

--- a/src/lib/PokerRoom.svelte
+++ b/src/lib/PokerRoom.svelte
@@ -32,11 +32,11 @@
     
     const numericVotes = room.users
       .map(user => user.vote)
-      .filter(vote => !isNaN(parseInt(vote)));
+      .filter(vote => !isNaN(parseFloat(vote)));
     
     if (numericVotes.length === 0) return null;
     
-    const sum = numericVotes.reduce((total, vote) => total + parseInt(vote), 0);
+    const sum = numericVotes.reduce((total, vote) => total + parseFloat(vote), 0);
     return (sum / numericVotes.length).toFixed(1);
   }
   


### PR DESCRIPTION
## Summary
- update card values for estimates to include `0.5`, limit high end to `8`
- allow a coffee cup card for taking a break
- handle decimal averages using `parseFloat`
- document new voting options

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d28e002e88326bc3aba0548a3a964